### PR TITLE
#3 Fix AutoSuggest file name for unix based file-systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "autocomplete"
   ],
   "license": "MIT",
-  "main": "Autosuggest.vue",
+  "main": "AutoSuggest.vue",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/soraino/v-autosuggest.git"


### PR DESCRIPTION
Fix issue with Unix based file systems which are case sensitive.

AutoSuggest.vue is the file name for the file, therefore the exact same name is used in the package.json which identifies the file location